### PR TITLE
Table view data source proxy

### DIFF
--- a/Sources/LUExpandableTableView.swift
+++ b/Sources/LUExpandableTableView.swift
@@ -148,7 +148,7 @@ open class LUExpandableTableView: UITableView {
     
     // MARK: - Data Source Proxy
     
-    public var dataSourceProxy: UITableViewDataSource? {
+    public weak var dataSourceProxy: UITableViewDataSource? {
         didSet {
             // Reset data source to refresh cached responders
             dataSource = nil

--- a/Sources/LUExpandableTableView.swift
+++ b/Sources/LUExpandableTableView.swift
@@ -145,6 +145,31 @@ open class LUExpandableTableView: UITableView {
         reloadSections(IndexSet(goodIndexes), with: animation)
         endUpdates()
     }
+    
+    // MARK: - Data Source Proxy
+    
+    public var dataSourceProxy: UITableViewDataSource? {
+        didSet {
+            // Reset data source to refresh cached responders
+            dataSource = nil
+            dataSource = self
+        }
+    }
+    
+    // MARK: - NSObjectProtocol
+    
+    override open func responds(to aSelector: Selector!) -> Bool {
+        return super.responds(to: aSelector) || (dataSourceProxy != nil ? dataSourceProxy!.responds(to: aSelector) : false)
+    }
+    
+    override open func forwardingTarget(for aSelector: Selector!) -> Any? {
+        if let delegateProxy = dataSourceProxy, delegateProxy.responds(to: aSelector) {
+            return delegateProxy
+        } else {
+            return super.forwardingTarget(for: aSelector)
+        }
+    }
+    
 }
 
 // MARK: - UITableViewDelegate


### PR DESCRIPTION
This PR makes it possible to implement additional table view data source functions which are not handled by `LUExpandableTableView` such as:
```swift
func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
```

This resolves issue #15. 
